### PR TITLE
Preserve file scheme if it was used explicitly

### DIFF
--- a/urlpath_unix.go
+++ b/urlpath_unix.go
@@ -17,7 +17,7 @@ func isAbsURL(u *url.URL) bool {
 }
 
 func toString(u *url.URL) string {
-	if !isFileURL(u) {
+	if u.Scheme != "" {
 		return u.Scheme + "://" + u.Host + path.Join("/", u.Path)
 	}
 	return path.Clean(u.Path)
@@ -25,15 +25,9 @@ func toString(u *url.URL) string {
 
 func normalize(u, wd *url.URL) string {
 	if u.Scheme != "" || u.Host != "" {
-		if u.Scheme == "" {
-			u.Scheme = "file"
-		}
 		u.Path = path.Clean(u.Path)
 	} else {
 		u.Scheme = wd.Scheme
-		if u.Scheme == "" {
-			u.Scheme = "file"
-		}
 		u.Host = wd.Host
 		if !path.IsAbs(u.Path) {
 			u.Path = path.Join(wd.Path, u.Path)

--- a/urlpath_unix_test.go
+++ b/urlpath_unix_test.go
@@ -18,7 +18,7 @@ func TestAbs(t *testing.T) {
 		{"../test.txt", "mem:///home/user", "mem:///home/test.txt"},
 		{"/home/user", "mem:///test", "mem:///home/user"},
 		{"/home/user", "mem:///test", "mem:///home/user"},
-		{"file:///home/user", "mem:///test", "/home/user"},
+		{"file:///home/user", "mem:///test", "file:///home/user"},
 		{"http://example.com/test.txt", "http://example.com:8888", "http://example.com/test.txt"},
 		{"./", "mem:///test", "mem:///test"},
 	}
@@ -55,7 +55,7 @@ func TestDir(t *testing.T) {
 		{"/home/user/test.txt", "/home/user"},
 		{"./test.txt", "."},
 		{"/home/user/../test.txt", "/home"},
-		{"file:///home/user/test.txt", "/home/user"},
+		{"file:///home/user/test.txt", "file:///home/user"},
 		{"mem:///home/user/test.txt", "mem:///home/user"},
 		{"http://localhost:8118/home/user/test.txt", "http://localhost:8118/home/user"},
 		// FIXME: behavior is inconsistent with Base.
@@ -89,7 +89,7 @@ func TestExt(t *testing.T) {
 func TestClean(t *testing.T) {
 	tests := [][2]string{
 		{"", "."},
-		{"file:///home/user/../test.txt", "/home/test.txt"},
+		{"file:///home/user/../test.txt", "file:///home/test.txt"},
 		{"mem:///home/user/test.txt", "mem:///home/user/test.txt"},
 		{"mem:///home/user/./test.txt", "mem:///home/user/test.txt"},
 		{"mem:///home/user/../test.txt", "mem:///home/test.txt"},
@@ -123,6 +123,8 @@ func TestIsAbs(t *testing.T) {
 
 func TestJoin(t *testing.T) {
 	tests := [][3]string{
+		{"/home/user", "test.txt", "/home/user/test.txt"},
+		{"file:///home/user", "test.txt", "file:///home/user/test.txt"},
 		{"mem:///home/user", "test.txt", "mem:///home/user/test.txt"},
 		{"mem:///home/user", "mem:///test.txt", "mem:///home/user/test.txt"},
 		{"/home/user", "mem:///test.txt", "/home/user/test.txt"},
@@ -136,8 +138,9 @@ func TestJoin(t *testing.T) {
 
 func TestSplit(t *testing.T) {
 	tests := [][3]string{
+		{"/home/user/test.txt", "/home/user", "test.txt"},
 		{"mem:///home/user/test.txt", "mem:///home/user", "test.txt"},
-		{"file:///home/user/test.txt", "/home/user", "test.txt"},
+		{"file:///home/user/test.txt", "file:///home/user", "test.txt"},
 		{"http://localhost:8118/home/user/test.txt", "http://localhost:8118/home/user", "test.txt"},
 	}
 	for i, test := range tests {

--- a/urlpath_windows_test.go
+++ b/urlpath_windows_test.go
@@ -10,7 +10,30 @@ import (
 	"github.com/foohq/urlpath"
 )
 
-// TODO: write Abs tests!
+func TestAbs(t *testing.T) {
+	tests := [][3]string{
+		{"", "", "/"},
+		{"test.txt", "", "/test.txt"},
+		{"test.txt", "mem:///home/user", "mem:///home/user/test.txt"},
+		{"../test.txt", "mem:///home/user", "mem:///home/test.txt"},
+		{"/home/user", "mem:///test", "mem:///home/user"},
+		{"/home/user", "mem:///test", "mem:///home/user"},
+		{"file:///home/user", "mem:///test", "file:///home/user"},
+		{"http://example.com/test.txt", "http://example.com:8888", "http://example.com/test.txt"},
+		{"./", "mem:///test", "mem:///test"},
+		{"//127.0.0.1/home/user/test.txt", "C:/home/user", "//127.0.0.1/home/user/test.txt"},
+		{"file://127.0.0.1/home/user/test.txt", "C:/home/user", "file://127.0.0.1/home/user/test.txt"},
+		{"file://127.0.0.1/home/user/test.txt", "file://C:/home/user", "file://127.0.0.1/home/user/test.txt"},
+		{"C:/home/user/test.txt", "file://127.0.0.1/home/user", "C:/home/user/test.txt"},
+		{"file:///C:/home/user/test.txt", "file://127.0.0.1/home/user", "file:///C:/home/user/test.txt"},
+		{"C:/home/user/test.txt", "mem:///home/user", "C:/home/user/test.txt"},
+	}
+	for i, test := range tests {
+		abs, err := urlpath.Abs(test[0], test[1])
+		require.NoError(t, err)
+		require.Equal(t, test[2], abs, "test %d/%d failed", i+1, len(tests))
+	}
+}
 
 func TestBase(t *testing.T) {
 	tests := [][2]string{
@@ -42,15 +65,15 @@ func TestDir(t *testing.T) {
 		{"/home/user/test.txt", "/home/user"},
 		{"./test.txt", "."},
 		{"/home/user/../test.txt", "/home"},
-		{"file:///home/user/test.txt", "/home/user"},
+		{"file:///home/user/test.txt", "file:///home/user"},
 		{"mem:///home/user/test.txt", "mem:///home/user"},
 		{"http://localhost:8118/home/user/test.txt", "http://localhost:8118/home/user"},
 		// FIXME: behavior is inconsistent with Base.
 		{"http://localhost:8118", "http://localhost:8118/"},
 		{"//127.0.0.1/home/user/test.txt", "//127.0.0.1/home/user"},
-		{"file://127.0.0.1/home/user/test.txt", "//127.0.0.1/home/user"},
+		{"file://127.0.0.1/home/user/test.txt", "file://127.0.0.1/home/user"},
 		{"C:/home/user/test.txt", "C:/home/user"},
-		{"file:///C:/home/user/test.txt", "C:/home/user"},
+		{"file:///C:/home/user/test.txt", "file:///C:/home/user"},
 	}
 	for i, test := range tests {
 		base, err := urlpath.Dir(test[0])
@@ -84,16 +107,16 @@ func TestExt(t *testing.T) {
 func TestClean(t *testing.T) {
 	tests := [][2]string{
 		{"", "."},
-		{"file:///home/user/../test.txt", "/home/test.txt"},
+		{"file:///home/user/../test.txt", "file:///home/test.txt"},
 		{"mem:///home/user/test.txt", "mem:///home/user/test.txt"},
 		{"mem:///home/user/./test.txt", "mem:///home/user/test.txt"},
 		{"mem:///home/user/../test.txt", "mem:///home/test.txt"},
 		{"http://localhost:8118/home/user/../test.txt", "http://localhost:8118/home/test.txt"},
 		{"http://localhost:8118", "http://localhost:8118/"},
 		{"//127.0.0.1/home/user/../test.txt", "//127.0.0.1/home/test.txt"},
-		{"file://127.0.0.1/home/user/../test.txt", "//127.0.0.1/home/test.txt"},
+		{"file://127.0.0.1/home/user/../test.txt", "file://127.0.0.1/home/test.txt"},
 		{"C:/home/user/../test.txt", "C:/home/test.txt"},
-		{"file:///C:/home/user/../test.txt", "C:/home/test.txt"},
+		{"file:///C:/home/user/../test.txt", "file:///C:/home/test.txt"},
 	}
 	for i, test := range tests {
 		clean, err := urlpath.Clean(test[0])
@@ -130,9 +153,9 @@ func TestJoin(t *testing.T) {
 		{"mem:///home/user", "mem:///test.txt", "mem:///home/user/test.txt"},
 		{"/home/user", "mem:///test.txt", "/home/user/test.txt"},
 		{"//127.0.0.1/home/user", "test.txt", "//127.0.0.1/home/user/test.txt"},
-		{"file://127.0.0.1/home/user", "test.txt", "//127.0.0.1/home/user/test.txt"},
+		{"file://127.0.0.1/home/user", "test.txt", "file://127.0.0.1/home/user/test.txt"},
 		{"C:/home/user", "test.txt", "C:/home/user/test.txt"},
-		{"file:///C:/home/user", "test.txt", "C:/home/user/test.txt"},
+		{"file:///C:/home/user", "test.txt", "file:///C:/home/user/test.txt"},
 	}
 	for i, test := range tests {
 		join, err := urlpath.Join(test[0], test[1])
@@ -144,12 +167,12 @@ func TestJoin(t *testing.T) {
 func TestSplit(t *testing.T) {
 	tests := [][3]string{
 		{"mem:///home/user/test.txt", "mem:///home/user", "test.txt"},
-		{"file:///home/user/test.txt", "/home/user", "test.txt"},
+		{"file:///home/user/test.txt", "file:///home/user", "test.txt"},
 		{"http://localhost:8118/home/user/test.txt", "http://localhost:8118/home/user", "test.txt"},
 		{"//127.0.0.1/home/user/test.txt", "//127.0.0.1/home/user", "test.txt"},
-		{"file://127.0.0.1/home/user/test.txt", "//127.0.0.1/home/user", "test.txt"},
+		{"file://127.0.0.1/home/user/test.txt", "file://127.0.0.1/home/user", "test.txt"},
 		{"C:/home/user/test.txt", "C:/home/user", "test.txt"},
-		{"file:///C:/home/user/test.txt", "C:/home/user", "test.txt"},
+		{"file:///C:/home/user/test.txt", "file:///C:/home/user", "test.txt"},
 	}
 	for i, test := range tests {
 		dir, file, err := urlpath.Split(test[0])
@@ -159,20 +182,15 @@ func TestSplit(t *testing.T) {
 	}
 }
 
-/*func TestMatch(t *testing.T) {
-	tests := map[string]bool{
-		"":                           false,
-		"/home/user/test.txt":        true,
-		"./test.txt":                 false,
-		"/home/user/../test.txt":     true,
-		"file:///home/user/test.txt": true,
-		"mem:///home/user/test.txt":  true,
-		"http://localhost:8118/home/user/test.txt": true,
-		"http://localhost:8118":                    false,
+func TestMatch(t *testing.T) {
+	tests := [][2]string{
+		{"http://localhost:????/*.txt", "http://localhost:8118/test.txt"},
+		{"*:///home/user/test.txt", "mem:///home/user/test.txt"},
+		{"/home/user/*.txt", "/home/user/test.txt"},
 	}
-	for name, is := range tests {
-		match, err := uri.Match("*.txt", name)
+	for i, test := range tests {
+		match, err := urlpath.Match(test[0], test[1])
 		require.NoError(t, err)
-		require.Equal(t, is, match, "test %q failed", name)
+		require.True(t, match, "test %d/%d failed", i+1, len(tests))
 	}
-}*/
+}


### PR DESCRIPTION
For instance "file:///home/user/test.txt" is no longer truncated to "/home/user/test.txt".